### PR TITLE
Add lifetime finalization test and fix length calculation

### DIFF
--- a/analysis/Lifetime.py
+++ b/analysis/Lifetime.py
@@ -51,6 +51,7 @@ class LifetimeAnalysis(MembraneAnalysisBase):
             starts = np.where(np.diff(np.pad(arr, (1, 0))) == 1)[0]
             ends = np.where(np.diff(np.pad(arr, (0, 1))) == -1)[0]
             for s, e in zip(starts, ends):
-                if e - s > 1:
-                    lifetimes[resid].append(e - s)
+                length = e - s + 1
+                if length > 1:
+                    lifetimes[resid].append(length)
         self.results = dict(lifetimes)

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -1,0 +1,20 @@
+import numpy as np
+from analysis.Lifetime import LifetimeAnalysis
+
+class DummyUniverse:
+    def __init__(self):
+        self.dimensions = [100, 100, 40]
+        self.trajectory = [None]
+
+class DummyResidue:
+    def __init__(self, resid):
+        self.resid = resid
+
+
+def test_finalize_calculates_lifetimes():
+    u = DummyUniverse()
+    analysis = LifetimeAnalysis(u, lipids=[], NL="TRIO", water="TIP3")
+    analysis.trio_residues = [DummyResidue(1)]
+    analysis.state = {1: [1, 1, 0, 1, 1, 1]}
+    analysis._finalize()
+    assert analysis.results[1] == [2, 3]


### PR DESCRIPTION
## Summary
- add a unit test for LifetimeAnalysis finalization
- adjust `_finalize` logic so lifetimes are counted with inclusive frame indices

